### PR TITLE
Daemon should support reload config

### DIFF
--- a/daemon/README.md
+++ b/daemon/README.md
@@ -10,7 +10,7 @@
 ```go
 type Daemon interface {
 	Start()
-	ReloadConfig(config config.Config) error
+	LoadConfig(config config.Config) error
 }
 ```
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -2,44 +2,39 @@ package daemon
 
 import (
 	"github.com/Clever/sphinx/config"
-	"github.com/Clever/sphinx/ratelimiter"
-	"github.com/stretchr/testify/mock"
-	"net/http"
 	"testing"
 )
 
-type MockHandler struct {
-	mock.Mock
-}
-
-func (h MockHandler) ServeHTTP(rw http.ResponseWriter, r *http.Request) {
-	_ = h.Mock.Called(rw, r)
-}
-
-var anyRateLimiter = mock.AnythingOfTypeArgument("*ratelimiter.rateLimiter")
-
-func (h MockHandler) SetRateLimiter(r ratelimiter.RateLimiter) {
-	_ = h.Mock.Called(r)
-}
-
 func TestConfigReload(t *testing.T) {
-	conf, _ := config.New("../example.yaml")
+	conf, err := config.New("../example.yaml")
+	if err != nil {
+		t.Fatal("Error loading config: " + err.Error())
+	}
 	d := daemon{}
-	mHandler := new(MockHandler)
-	mHandler.Mock.On("SetRateLimiter", anyRateLimiter).Return(nil).Once()
-	d.handler = mHandler
-	d.ReloadConfig(conf)
-	if d.rateLimiter == nil {
-		t.Fatal("Didn't assign rate limiter")
+	d.LoadConfig(conf)
+	if d.handler == nil {
+		t.Fatal("Didn't assign handler")
 	}
 }
 
 func TestFailedReload(t *testing.T) {
-	conf, _ := config.New("../example.yaml")
-	daemon, _ := New(conf)
+	conf, err := config.New("../example.yaml")
+	if err != nil {
+		t.Fatal("Error loading config: " + err.Error())
+	}
+	daemon, err := New(conf)
+	if err != nil {
+		t.Fatal("Error creating new daemon: " + err.Error())
+	}
 	conf2 := config.Config{}
-	err := daemon.ReloadConfig(conf2)
+	err = daemon.LoadConfig(conf2)
 	if err == nil {
 		t.Fatal("Should have errored on empty configuration")
+	}
+
+	conf.Proxy.Listen = ":1000"
+	err = daemon.LoadConfig(conf)
+	if err == nil {
+		t.Fatalf("Should have errored on changed listen port")
 	}
 }

--- a/handlers/README.md
+++ b/handlers/README.md
@@ -5,27 +5,17 @@
 
 ## Usage
 
-#### type SphinxHandler
-
-```go
-type SphinxHandler interface {
-	http.Handler
-	SetRateLimiter(rateLimiter ratelimiter.RateLimiter)
-}
-```
-
-
 #### func  NewHTTPLimiter
 
 ```go
-func NewHTTPLimiter(rateLimiter ratelimiter.RateLimiter, proxy http.Handler) SphinxHandler
+func NewHTTPLimiter(rateLimiter ratelimiter.RateLimiter, proxy http.Handler) http.Handler
 ```
 NewHTTPLimiter returns an http.Handler that rate limits and proxies requests.
 
 #### func  NewHTTPLogger
 
 ```go
-func NewHTTPLogger(rateLimiter ratelimiter.RateLimiter, proxy http.Handler) SphinxHandler
+func NewHTTPLogger(rateLimiter ratelimiter.RateLimiter, proxy http.Handler) http.Handler
 ```
 NewHTTPLogger returns an http.Handler that logs the results of rate limiting
 requests, but actually proxies everything.

--- a/handlers/http.go
+++ b/handlers/http.go
@@ -12,11 +12,6 @@ import (
 	"strings"
 )
 
-type SphinxHandler interface {
-	http.Handler
-	SetRateLimiter(rateLimiter ratelimiter.RateLimiter)
-}
-
 func stringifyHeaders(headers http.Header) *bytes.Buffer {
 	buf := &bytes.Buffer{}
 	for header, values := range headers {
@@ -62,10 +57,6 @@ func (hrl httpRateLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	hrl.proxy.ServeHTTP(w, r)
 }
 
-func (hrl *httpRateLimiter) SetRateLimiter(rateLimiter ratelimiter.RateLimiter) {
-	hrl.rateLimiter = rateLimiter
-}
-
 type httpRateLogger httpRateLimiter
 
 func (hrl httpRateLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -83,10 +74,6 @@ func (hrl httpRateLogger) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		log.Printf("[%s] BUCKET FULL", guid)
 	}
 	hrl.proxy.ServeHTTP(w, r)
-}
-
-func (hrl *httpRateLogger) SetRateLimiter(rateLimiter ratelimiter.RateLimiter) {
-	hrl.rateLimiter = rateLimiter
 }
 
 func uintToString(num uint) string {
@@ -131,12 +118,12 @@ func addRateLimitHeaders(w http.ResponseWriter, statuses []ratelimiter.Status) {
 }
 
 // NewHTTPLimiter returns an http.Handler that rate limits and proxies requests.
-func NewHTTPLimiter(rateLimiter ratelimiter.RateLimiter, proxy http.Handler) SphinxHandler {
+func NewHTTPLimiter(rateLimiter ratelimiter.RateLimiter, proxy http.Handler) http.Handler {
 	return &httpRateLimiter{rateLimiter: rateLimiter, proxy: proxy}
 }
 
 // NewHTTPLogger returns an http.Handler that logs the results of rate limiting requests, but
 // actually proxies everything.
-func NewHTTPLogger(rateLimiter ratelimiter.RateLimiter, proxy http.Handler) SphinxHandler {
+func NewHTTPLogger(rateLimiter ratelimiter.RateLimiter, proxy http.Handler) http.Handler {
 	return &httpRateLogger{rateLimiter: rateLimiter, proxy: proxy}
 }

--- a/main.go
+++ b/main.go
@@ -43,18 +43,20 @@ func main() {
 func sighupHandler(d daemon.Daemon) {
 	conf, err := config.New(*configfile)
 	if err != nil {
-		log.Println("RELOAD_CONFIG_FILE_FAILED: %s", err.Error())
+		log.Println("RELOAD_CONFIG_FILE_FAILED: " + err.Error())
+		return
 	}
-	err = d.ReloadConfig(conf)
+	err = d.LoadConfig(conf)
 	if err != nil {
-		log.Println("RELOAD_CONFIG_FILE_FAILED: %s", err.Error())
+		log.Println("RELOAD_CONFIG_FILE_FAILED: " + err.Error())
+		return
 	}
 	log.Println("Reloaded config file")
 }
 
 // setupSighupHandler craetes a channel to listen for HUP signals and process them.
 func setupSighupHandler(d daemon.Daemon, handler func(daemon.Daemon)) {
-	sigc := make(chan os.Signal, 1)
+	sigc := make(chan os.Signal)
 	signal.Notify(sigc, syscall.SIGHUP)
 	go func() {
 		// Listen for HUP signals "forever", calling the hup-handler each time

--- a/main_test.go
+++ b/main_test.go
@@ -99,8 +99,7 @@ func TestSighupHandler(t *testing.T) {
 	select {
 	case <-ranHandler:
 	case <-timeout:
-		t.Error("Didn't run handler")
-		return
+		t.Fatal("Didn't run handler")
 	}
 
 	// Try calling again and make sure it still happens
@@ -108,7 +107,6 @@ func TestSighupHandler(t *testing.T) {
 	select {
 	case <-ranHandler:
 	case <-timeout:
-		t.Error("Didn't run handler second time")
-		return
+		t.Fatal("Didn't run handler second time")
 	}
 }


### PR DESCRIPTION
This change adds support for changing the limit configuration of a running sphinxd.
It does this by listening for the HUP signal, reloading the config file when
that happens, and changing the ratelimiter object.

We aren't worrying about pre-existing buckets that get affected when we reload,
they will expire out.

I also tested this manually with Apache Bench
