### PR TITLE
daemon: Added Sphinx health check route.

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -23,7 +23,11 @@ type daemon struct {
 
 func (d *daemon) Start() {
 	log.Printf("Listening on %s", d.proxy.Listen)
-	log.Fatal(http.ListenAndServe(d.proxy.Listen, d))
+	http.HandleFunc("/sphinx/health/check", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusOK)
+	})
+	http.Handle("/", d)
+	log.Fatal(http.ListenAndServe(d.proxy.Listen, nil))
 	return
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -46,7 +46,7 @@ var localServerHost = "http://localhost" + localServerPort
 var localProxyHost = "http://localhost:6634"
 
 func setUpDaemonWithLocalServer() error {
-	// Set up a local server that 404s everywhere except one route.
+	// Set up a local server that 404s everywhere except route '/healthyroute'.
 	mux := http.NewServeMux()
 	mux.HandleFunc("/healthyroute", func(rw http.ResponseWriter, req *http.Request) {
 		rw.Write([]byte("healthy"))
@@ -101,7 +101,7 @@ func testProxyRequest(t *testing.T, path string, expectedStatus int, expectedBod
 func TestHealthCheck(t *testing.T) {
 	err := setUpDaemonWithLocalServer()
 	if err != nil {
-		t.Fatalf("DAEMON_SETUP_FAILED: %s", err.Error())
+		t.Fatalf("Test daemon setup failed: %s", err.Error())
 	}
 
 	// Test a route that should be proxied to 404.

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -2,6 +2,8 @@ package daemon
 
 import (
 	"github.com/Clever/sphinx/config"
+	"io/ioutil"
+	"net/http"
 	"testing"
 )
 
@@ -37,4 +39,77 @@ func TestFailedReload(t *testing.T) {
 	if err == nil {
 		t.Fatalf("Should have errored on changed listen port")
 	}
+}
+
+var localServerPort = ":8081"
+var localServerHost = "http://localhost" + localServerPort
+var localProxyHost = "http://localhost:6634"
+
+func setUpDaemonWithLocalServer() error {
+	// Set up a local server that 404s everywhere except one route.
+	mux := http.NewServeMux()
+	mux.HandleFunc("/healthyroute", func(rw http.ResponseWriter, req *http.Request) {
+		rw.Write([]byte("healthy"))
+	})
+	mux.HandleFunc("/", func(rw http.ResponseWriter, req *http.Request) {
+		rw.WriteHeader(http.StatusNotFound)
+		rw.Write([]byte("404"))
+	})
+	go http.ListenAndServe(localServerPort, mux)
+
+	// Set up the daemon to proxy to the local server.
+	conf, err := config.New("../example.yaml")
+	if err != nil {
+		return err
+	}
+	conf.Proxy.Host = localServerHost
+
+	daemon, err := New(conf)
+	if err != nil {
+		return err
+	}
+
+	go daemon.Start()
+	return nil
+}
+
+// testProxyRequest calls the proxy server at the given path and verifies that
+// the request returns the given HTTP status and body content.
+func testProxyRequest(t *testing.T, path string, expectedStatus int, expectedBody string) {
+	resp, err := http.Get(localProxyHost + path)
+	if err != nil {
+		t.Fatalf("Proxy request failed: %s", err.Error())
+	}
+
+	if resp.StatusCode != expectedStatus {
+		t.Fatalf("Response status with path %s does not match expected value.  Actual: %d.  Expected: %d.",
+			path, resp.StatusCode, expectedStatus)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("Couldn't read response body: %s", err.Error())
+	}
+
+	bodyStr := string(body)
+	if bodyStr != expectedBody {
+		t.Fatalf("Response body does not match expected value. Actual: \"%s\" Expected: \"%s\"",
+			bodyStr, expectedBody)
+	}
+}
+
+func TestHealthCheck(t *testing.T) {
+	err := setUpDaemonWithLocalServer()
+	if err != nil {
+		t.Fatalf("DAEMON_SETUP_FAILED: %s", err.Error())
+	}
+
+	// Test a route that should be proxied to 404.
+	testProxyRequest(t, "/helloworld", http.StatusNotFound, "404")
+
+	// Test a route that should be proxied to a valid response.
+	testProxyRequest(t, "/healthyroute", http.StatusOK, "healthy")
+
+	// Test the health check.
+	testProxyRequest(t, "/sphinx/health/check", http.StatusOK, "")
 }


### PR DESCRIPTION
This adds a health check route for Sphinx that isn't proxied.  It lets services check to see if Sphinx itself is still running.

The route is currently `/sphinx/health/check`.