### PR TITLE
health-check: Change health check to run on a separate port.

### DIFF
--- a/config/README.md
+++ b/config/README.md
@@ -18,10 +18,10 @@ yaml
 
 ```go
 type Config struct {
-	Proxy   Proxy
-	Health  Health
-	Limits  map[string]Limit
-	Storage map[string]string
+	Proxy       Proxy
+	HealthCheck HealthCheck `yaml:"health-check"`
+	Limits      map[string]Limit
+	Storage     map[string]string
 }
 ```
 
@@ -51,16 +51,16 @@ func New(path string) (Config, error)
 ```
 New takes in a path to a configuration yaml and returns a Configuration.
 
-#### type Health
+#### type HealthCheck
 
 ```go
-type Health struct {
+type HealthCheck struct {
 	Port     string
 	Endpoint string
 }
 ```
 
-Health holds the yaml data for how to run the health check service.
+HealthCheck holds the yaml data for how to run the health check service.
 
 #### type Limit
 

--- a/config/README.md
+++ b/config/README.md
@@ -57,6 +57,7 @@ New takes in a path to a configuration yaml and returns a Configuration.
 type HealthCheck struct {
 	Port     string
 	Endpoint string
+	Enabled  bool
 }
 ```
 

--- a/config/README.md
+++ b/config/README.md
@@ -19,6 +19,7 @@ yaml
 ```go
 type Config struct {
 	Proxy   Proxy
+	Health  Health
 	Limits  map[string]Limit
 	Storage map[string]string
 }
@@ -49,6 +50,17 @@ all be private, but right now tests depend on parsing bytes into yaml
 func New(path string) (Config, error)
 ```
 New takes in a path to a configuration yaml and returns a Configuration.
+
+#### type Health
+
+```go
+type Health struct {
+	Port     string
+	Endpoint string
+}
+```
+
+Health holds the yaml data for how to run the health check service.
 
 #### type Limit
 

--- a/config/config.go
+++ b/config/config.go
@@ -30,6 +30,7 @@ type Proxy struct {
 type HealthCheck struct {
 	Port     string
 	Endpoint string
+	Enabled  bool
 }
 
 // Limit holds the yaml data for one of the limits in the config file
@@ -70,7 +71,7 @@ func ValidateConfig(config Config) error {
 	}
 
 	// HealthCheck section is optional.
-	if config.HealthCheck.Port != "" {
+	if config.HealthCheck.Enabled {
 		colonIdx := strings.LastIndex(config.Proxy.Listen, ":") + 1
 		proxyPort := config.Proxy.Listen[colonIdx:]
 		if config.HealthCheck.Port == proxyPort {

--- a/config/config.go
+++ b/config/config.go
@@ -13,10 +13,10 @@ import (
 
 // Config holds the yaml data for the config file
 type Config struct {
-	Proxy   Proxy
-	Health  Health
-	Limits  map[string]Limit
-	Storage map[string]string
+	Proxy       Proxy
+	HealthCheck HealthCheck `yaml:"health-check"`
+	Limits      map[string]Limit
+	Storage     map[string]string
 }
 
 // Proxy holds the yaml data for the proxy option in the config file
@@ -26,8 +26,8 @@ type Proxy struct {
 	Listen  string
 }
 
-// Health holds the yaml data for how to run the health check service.
-type Health struct {
+// HealthCheck holds the yaml data for how to run the health check service.
+type HealthCheck struct {
 	Port     string
 	Endpoint string
 }
@@ -69,11 +69,11 @@ func ValidateConfig(config Config) error {
 		return errors.New("could not parse proxy.host. Must include scheme (eg. https://example.com)")
 	}
 
-	// Health section is optional.
-	if config.Health.Port != "" {
+	// HealthCheck section is optional.
+	if config.HealthCheck.Port != "" {
 		colonIdx := strings.LastIndex(config.Proxy.Listen, ":") + 1
 		proxyPort := config.Proxy.Listen[colonIdx:]
-		if config.Health.Port == proxyPort {
+		if config.HealthCheck.Port == proxyPort {
 			return fmt.Errorf("health service port cannot match proxy.listen port")
 		}
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -127,6 +127,24 @@ limits:
 	}
 }
 
+func TestInvalidHealthConfig(t *testing.T) {
+	buf := bytes.NewBufferString(`
+proxy:
+  handler: http
+  host: http://proxy.example.com
+  listen: localhost:8080
+health:
+  port: 8080
+  endpoint: "/health/check"
+`)
+	_, err := LoadAndValidateYaml(buf.Bytes())
+	if err == nil ||
+		!strings.Contains(err.Error(), "health service port cannot match proxy.listen port") {
+		t.Error("Expected health service port error.")
+	}
+
+}
+
 func TestInvalidStorageConfig(t *testing.T) {
 	baseBuf := bytes.NewBufferString(`
 proxy:

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,12 +21,12 @@ func TestConfigurationFileLoading(t *testing.T) {
 		t.Error("expected http for Proxy.Handler")
 	}
 
-	if config.Health.Port != "60002" {
-		t.Error("expected 60002 for Health.Port")
+	if config.HealthCheck.Port != "60002" {
+		t.Error("expected 60002 for HealthCheck.Port")
 	}
 
-	if config.Health.Endpoint != "/health/check" {
-		t.Error("expected /health/check for Health.Port")
+	if config.HealthCheck.Endpoint != "/health/check" {
+		t.Error("expected /health/check for HealthCheck.Port")
 	}
 
 	if len(config.Limits) != 4 {
@@ -135,13 +135,13 @@ limits:
 	}
 }
 
-func TestInvalidHealthConfig(t *testing.T) {
+func TestInvalidHealthCheckConfig(t *testing.T) {
 	buf := bytes.NewBufferString(`
 proxy:
   handler: http
   host: http://proxy.example.com
   listen: localhost:8080
-health:
+health-check:
   port: 8080
   endpoint: "/health/check"
 `)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -21,6 +21,14 @@ func TestConfigurationFileLoading(t *testing.T) {
 		t.Error("expected http for Proxy.Handler")
 	}
 
+	if config.Health.Port != "60002" {
+		t.Error("expected 60002 for Health.Port")
+	}
+
+	if config.Health.Endpoint != "/health/check" {
+		t.Error("expected /health/check for Health.Port")
+	}
+
 	if len(config.Limits) != 4 {
 		t.Error("expected 4 bucket definitions")
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -142,6 +142,7 @@ proxy:
   host: http://proxy.example.com
   listen: localhost:8080
 health-check:
+  enabled: true
   port: 8080
   endpoint: "/health/check"
 `)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -35,8 +35,8 @@ func setUpHealthCheckService(port string, endpoint string) {
 
 func (d *daemon) Start() {
 	log.Printf("Listening on %s", d.proxy.Listen)
-	// Only set up the health check service if a port was supplied for one.
-	if d.healthCheck.Port != "" {
+	// Only set up the health check service if it is enabled.
+	if d.healthCheck.Enabled {
 		setUpHealthCheckService(d.healthCheck.Port, d.healthCheck.Endpoint)
 	}
 	log.Fatal(http.ListenAndServe(d.proxy.Listen, d))

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -36,7 +36,10 @@ func setUpHealthCheckService(port string, endpoint string) {
 
 func (d *daemon) Start() {
 	log.Printf("Listening on %s", d.proxy.Listen)
-	setUpHealthCheckService(d.healthCheck.Port, d.healthCheck.Endpoint)
+	// Only set up the health check service if a port was supplied for one.
+	if d.healthCheck.Port != "" {
+		setUpHealthCheckService(d.healthCheck.Port, d.healthCheck.Endpoint)
+	}
 	log.Fatal(http.ListenAndServe(d.proxy.Listen, d))
 	return
 }

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -30,7 +30,6 @@ func setUpHealthCheckService(port string, endpoint string) {
 	mux.HandleFunc(endpoint, func(rw http.ResponseWriter, req *http.Request) {
 		rw.WriteHeader(http.StatusOK)
 	})
-	mux.Handle("/", http.NotFoundHandler())
 	go http.ListenAndServe(":"+port, mux)
 }
 

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -44,7 +44,7 @@ func TestFailedReload(t *testing.T) {
 var localServerPort = ":8081"
 var localServerHost = "http://localhost" + localServerPort
 var localProxyHost = "http://localhost:6634"
-var healthCheckUrl = "http://localhost:60002/health/check"
+var healthCheckURL = "http://localhost:60002/health/check"
 
 func setUpDaemonWithLocalServer() error {
 	// Set up a local server that 404s everywhere except route '/healthyroute'.
@@ -112,5 +112,5 @@ func TestHealthCheck(t *testing.T) {
 	testProxyRequest(t, localProxyHost+"/healthyroute", http.StatusOK, "healthy")
 
 	// Test the health check.
-	testProxyRequest(t, healthCheckUrl, http.StatusOK, "")
+	testProxyRequest(t, healthCheckURL, http.StatusOK, "")
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"fmt"
 	"github.com/Clever/sphinx/config"
 	"io/ioutil"
 	"net/http"
@@ -100,7 +101,7 @@ func testProxyRequest(t *testing.T, url string, expectedStatus int, expectedBody
 }
 
 func getHealthCheckURLFromPort(port string) string {
-	return "http://localhost:" + port + "/health/check"
+	return fmt.Sprintf("http://localhost:%s/health/check", port)
 }
 
 func TestHealthCheck(t *testing.T) {
@@ -144,10 +145,4 @@ func TestDaemonWithNoHealthCheck(t *testing.T) {
 
 	// Test a route that should be proxied to a valid response.
 	testProxyRequest(t, localProxyURL+"/healthyroute", http.StatusOK, "healthy")
-
-	// Health check request should fail.
-	if _, err := http.Get(getHealthCheckURLFromPort(healthCheckPort)); err == nil {
-		t.Fatalf("Health check request should have failed, but it did not.")
-	}
-
 }

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -100,10 +100,6 @@ func testProxyRequest(t *testing.T, url string, expectedStatus int, expectedBody
 	}
 }
 
-func getHealthCheckURLFromPort(port string) string {
-	return fmt.Sprintf("http://localhost:%s/health/check", port)
-}
-
 func TestHealthCheck(t *testing.T) {
 	localProxyListen := ":6634"
 	healthCheckPort := "60002"
@@ -121,8 +117,10 @@ func TestHealthCheck(t *testing.T) {
 	// Test a route that should be proxied to a valid response.
 	testProxyRequest(t, localProxyURL+"/healthyroute", http.StatusOK, "healthy")
 
+	healthCheckURL := fmt.Sprintf("http://localhost:%s/health/check", healthCheckPort)
+
 	// Test the health check.
-	testProxyRequest(t, getHealthCheckURLFromPort(healthCheckPort), http.StatusOK, "")
+	testProxyRequest(t, healthCheckURL, http.StatusOK, "")
 }
 
 func TestDaemonWithNoHealthCheck(t *testing.T) {

--- a/deb/sphinx/DEBIAN/control
+++ b/deb/sphinx/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: sphinx
-Version: 0.3.0
+Version: 0.3.1
 Section: base
 Priority: optional
 Architecture: amd64

--- a/example.yaml
+++ b/example.yaml
@@ -9,6 +9,10 @@ storage:
   host: localhost # redis hostname. not required for memory
   port: 6379      # redis port.     not required for memory
 
+health:
+  port: 60002
+  endpoint: "/health/check"
+
 limits:
   bearer-special:
     interval: 15  # in seconds

--- a/example.yaml
+++ b/example.yaml
@@ -10,6 +10,7 @@ storage:
   port: 6379      # redis port.     not required for memory
 
 health-check:
+  enabled: true
   port: 60002
   endpoint: "/health/check"
 

--- a/example.yaml
+++ b/example.yaml
@@ -9,7 +9,7 @@ storage:
   host: localhost # redis hostname. not required for memory
   port: 6379      # redis port.     not required for memory
 
-health:
+health-check:
   port: 60002
   endpoint: "/health/check"
 


### PR DESCRIPTION
This changes the health check service to run on a separate port, set in the YAML config.  


We probably want to bump the version for this change.  Let me know if I should do so.  