### PR TITLE
Sphinx will return NilStatus if allow-on-error = Yes

### DIFF
--- a/deb/sphinx/DEBIAN/control
+++ b/deb/sphinx/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: sphinx
-Version: 0.4.1
+Version: 0.5.0
 Section: base
 Priority: optional
 Architecture: amd64

--- a/handlers/README.md
+++ b/handlers/README.md
@@ -7,6 +7,7 @@
 
 ```go
 const (
+	// StatusTooManyRequests represents HTTP 429, missing from new/http
 	StatusTooManyRequests = 429 // not in net/http package
 )
 ```

--- a/handlers/http.go
+++ b/handlers/http.go
@@ -13,6 +13,7 @@ import (
 )
 
 const (
+	// StatusTooManyRequests represents HTTP 429, missing from net/http
 	StatusTooManyRequests = 429 // not in net/http package
 )
 
@@ -56,6 +57,7 @@ func (hrl httpRateLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	case err != nil && hrl.allowOnError:
 		log.Printf("[%s] ERROR: %s", guid, err)
 		log.Printf("[%s] WARNING: bypassing rate limiter due to Error", guid)
+		addRateLimitHeaders(w, []ratelimiter.Status{ratelimiter.NilStatus})
 		hrl.proxy.ServeHTTP(w, r)
 	case err != nil:
 		log.Printf("[%s] ERROR: %s", guid, err)

--- a/handlers/http_test.go
+++ b/handlers/http_test.go
@@ -244,7 +244,7 @@ var allowOnErrorCases = []struct {
 }
 
 // Tests the allowOnError flag feature
-func TestallowOnError(t *testing.T) {
+func TestAllowOnError(t *testing.T) {
 	for _, test := range allowOnErrorCases {
 		limiter := constructHTTPRateLimiter()
 		limiter.allowOnError = test.allowOnError
@@ -264,7 +264,11 @@ func TestallowOnError(t *testing.T) {
 		proxyMock.On("ServeHTTP", w, r).Return().Once()
 		limiter.ServeHTTP(w, r)
 
-		assertNoRateLimitHeaders(t, w.Header())
+		if test.allowOnError {
+			compareHeader(t, w.Header(), "X-Ratelimit-Limit", []string{"1"})
+			compareHeader(t, w.Header(), "X-Ratelimit-Remaining", []string{"1"})
+			compareHeader(t, w.Header(), "X-Ratelimit-Bucket", []string{"Unknown"})
+		}
 
 		if w.Code != test.ExpectedCode {
 			t.Fatalf("expected status %d, received %d", test.ExpectedCode, w.Code)

--- a/ratelimiter/README.md
+++ b/ratelimiter/README.md
@@ -5,6 +5,16 @@
 
 ## Usage
 
+```go
+var NilStatus = Status{
+	Capacity:  1,
+	Reset:     time.Now(),
+	Remaining: 1,
+	Name:      "Unknown",
+}
+```
+NilStatus for when acting as passive proxy
+
 #### type RateLimiter
 
 ```go

--- a/ratelimiter/ratelimiter.go
+++ b/ratelimiter/ratelimiter.go
@@ -90,3 +90,11 @@ func New(config config.Config) (RateLimiter, error) {
 	rateLimiter := &rateLimiter{limits: limits}
 	return rateLimiter, nil
 }
+
+// NilStatus for when acting as passive proxy
+var NilStatus = Status{
+	Capacity:  1,
+	Reset:     time.Now(),
+	Remaining: 1,
+	Name:      "Unknown",
+}

--- a/ratelimiter/ratelimiter_test.go
+++ b/ratelimiter/ratelimiter_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Clever/sphinx/limit"
 	"net/http"
 	"testing"
+	"time"
 )
 
 func returnLastAddStatus(rateLimiter RateLimiter, request common.Request, numAdds int) ([]Status, error) {
@@ -105,6 +106,25 @@ func TestSimpleAdd(t *testing.T) {
 		t.Fatalf("expected 0 remaining, found %d", status[0].Remaining)
 	} else if status[0].Name != "basic-simple" {
 		t.Fatalf("expected 'basic-simple' limit, found '%s'", status[0].Name)
+	}
+}
+
+// Test to ensure we build the correct nil Ratelimiter status
+func TestNilStatus(t *testing.T) {
+	if NilStatus.Capacity != 1 {
+		t.Fatalf("Expected NilStatus capacity to be 1")
+	}
+
+	if NilStatus.Reset.Unix() > time.Now().Unix() {
+		t.Fatalf("Expected NilStatus reset time to be in the past")
+	}
+
+	if NilStatus.Remaining != 1 {
+		t.Fatalf("Expected NilStatus remaining to be 1")
+	}
+
+	if NilStatus.Name != "Unknown" {
+		t.Fatalf("Expected NilStatus name to be 'Unknown'")
 	}
 }
 


### PR DESCRIPTION
What: Makes it so that we return a default ratelimit header when the "allow-on-error" setting is enabled and the leakybucket cannot be reached (ie, redis storage is down)

Why: The changes in 0.4.1 made it so that allow-on-error failure modes could result in no rate limit headers. We're concerned that the lack of a header could cause consumers to fail. 

See also: https://clever.atlassian.net/browse/APPS-131