### PR TITLE
add X-Request-Id header

### DIFF
--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Clever/sphinx/config"
 	"github.com/Clever/sphinx/handlers"
 	"github.com/Clever/sphinx/ratelimiter"
+	"github.com/pborman/uuid"
 )
 
 // Daemon represents a daemon server
@@ -49,6 +50,9 @@ func (d *daemon) Start() {
 }
 
 func (d *daemon) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
+	if req.Header.Get("X-Request-Id") == "" {
+		req.Header.Set("X-Request-Id", uuid.New())
+	}
 	d.handler.ServeHTTP(rw, req)
 }
 

--- a/handlers/http.go
+++ b/handlers/http.go
@@ -1,14 +1,15 @@
 package handlers
 
 import (
-	"github.com/Clever/leakybucket"
-	"github.com/Clever/sphinx/common"
-	"github.com/Clever/sphinx/ratelimiter"
-	"github.com/pborman/uuid"
 	"log"
 	"net/http"
 	"strconv"
 	"strings"
+
+	"github.com/Clever/leakybucket"
+	"github.com/Clever/sphinx/common"
+	"github.com/Clever/sphinx/ratelimiter"
+	"github.com/pborman/uuid"
 )
 
 const (
@@ -31,7 +32,7 @@ type httpRateLimiter struct {
 }
 
 func (hrl httpRateLimiter) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	guid := uuid.New()
+	guid := r.Header.Get("X-Request-Id")
 	request := common.HTTPToSphinxRequest(r)
 	matches, err := hrl.rateLimiter.Add(request)
 	switch {


### PR DESCRIPTION
This is so that anything with access to the request will have access to the id that the application logs with