### PR TITLE
write VERSION file before doing release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,9 @@ $(PKGS): golang-test-all-strict-deps
 bench: $(BENCHES)
 build: bin/sphinxd
 
+VERSION:
+	echo $(VERSION) > VERSION
+
 bin/sphinxd: *.go **/*.go
 	go build -o bin/sphinxd -gcflags "-N -l" -ldflags "-X main.version=v$(VERSION)-$(BRANCH)-$(SHA)$(GIT_DIRTY)" $(PKG)
 

--- a/circle.yml
+++ b/circle.yml
@@ -21,6 +21,6 @@ deployment:
     owner: Clever
     commands:
     - $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
-    - make deb && cp deb/sphinx.deb sphinx-amd64.deb && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN sphinx-amd64.deb
+    - make VERSION && make deb && cp deb/sphinx.deb sphinx-amd64.deb && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN sphinx-amd64.deb
 general:
   build_dir: ../.go_workspace/src/github.com/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME


### PR DESCRIPTION
Having the version in a `VERSION` file is required by our github-release circleci plugin: https://github.com/Clever/ci-scripts/blob/master/circleci/github-release

Merge to master previously failed due to missing `VERSION` file https://circleci.com/gh/Clever/sphinx/3