### PR TITLE
global limitkey for rate-limiting all requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+# v0.7.0: Add global limit key
+  * Allows global rate limiting irrespective of request content
+
 # v0.6.1: log routing + go 1.7
 
 # v0.6.0: Standardized request logging, X-Request-Id header

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -68,6 +68,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ea120c4cb72c3120dec6e5184ba2a59abbaec4138f40e07fbb5ce65abdeb249f"
+  inputs-digest = "8b925e515cf7befa151e96c301265aa139ece51615d3509194cb9be9a3153056"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -33,8 +33,8 @@ func TestConfigurationFileLoading(t *testing.T) {
 		t.Error("expected /health/check for HealthCheck.Port")
 	}
 
-	if len(config.Limits) != 4 {
-		t.Error("expected 4 bucket definitions")
+	if len(config.Limits) != 5 {
+		t.Error("expected 5 limit definitions")
 	}
 
 	for name, limit := range config.Limits {

--- a/example.yaml
+++ b/example.yaml
@@ -26,6 +26,7 @@ limits:
         names:
           - "Authorization"
       ip: ""      # ip keys require no configuration
+      global: ""  # global keys have NO affect when used with other key types
     matches:
       # both headers and paths matches should be true for limit to apply
       headers:
@@ -36,6 +37,16 @@ limits:
       paths:
         match_any:
           - "/special/resources/.*"
+
+  global-limit:
+    interval: 15
+    max: 500
+    keys:
+      global: ""  # global key has no configuration
+    matches:
+      paths:
+        match_any:
+          - "/generic/resources/.*"
 
   basic-simple:
     interval: 15
@@ -88,3 +99,4 @@ limits:
       paths:
         match_any:
           - "/special/resources/.*"
+

--- a/limit/limit.go
+++ b/limit/limit.go
@@ -2,14 +2,15 @@ package limit
 
 import (
 	"fmt"
+	"log"
+	"strings"
+	"time"
+
 	"github.com/Clever/leakybucket"
 	"github.com/Clever/sphinx/common"
 	"github.com/Clever/sphinx/config"
 	"github.com/Clever/sphinx/limitkeys"
 	"github.com/Clever/sphinx/matchers"
-	"log"
-	"strings"
-	"time"
 )
 
 // Limit has methods for matching and adding to a limit
@@ -164,9 +165,15 @@ func resolveLimitKeys(limitkeysConfig map[string]interface{}) ([]limitkeys.Limit
 				return []limitkeys.LimitKey{}, err
 			}
 			resolvedLimitkeys = append(resolvedLimitkeys, keys...)
+		case "global":
+			keys, err := limitkeys.NewHeaderLimitKeys(config)
+			if err != nil {
+				return []limitkeys.LimitKey{}, err
+			}
+			resolvedLimitkeys = append(resolvedLimitkeys, keys...)
 		default:
 			return []limitkeys.LimitKey{},
-				fmt.Errorf("only header and ip limitkeys allowed. Found: %s", name)
+				fmt.Errorf("only global, header and ip limitkeys allowed. Found: %s", name)
 		}
 	}
 

--- a/limitkeys/README.md
+++ b/limitkeys/README.md
@@ -21,6 +21,13 @@ func NewIPLimitKeys(config interface{}) ([]LimitKey, error)
 NewIPLimitKeys creates a slice of ipLimitKeys that returns a key based on
 request remoteaddr
 
+#### func  NewGlobalLimitKey
+
+```go
+func NewGlobalLimitKey(config interface{}) ([]LimitKey, error)
+```
+NewGlobalLimitKey creates a slice of globalLimitKey that always returns the same key
+
 #### type EmptyKeyError
 
 ```go

--- a/limitkeys/globallimitkey.go
+++ b/limitkeys/globallimitkey.go
@@ -1,0 +1,23 @@
+package limitkeys
+
+import (
+	"github.com/Clever/sphinx/common"
+)
+
+const globalLimitKeyValue = "global:sigelton-key"
+
+type globalLimitKey struct{}
+
+func (ilk globalLimitKey) Type() string {
+	return "global"
+}
+
+func (ilk globalLimitKey) Key(request common.Request) (string, error) {
+
+	return globalLimitKeyValue, nil
+}
+
+// NewGlobalLimitKey creates a slice of globalLimitKeys that always returns the same key
+func NewGlobalLimitKey(config interface{}) ([]LimitKey, error) {
+	return []LimitKey{globalLimitKey{}}, nil
+}

--- a/limitkeys/globallimitkey_test.go
+++ b/limitkeys/globallimitkey_test.go
@@ -1,0 +1,25 @@
+package limitkeys
+
+import (
+	"testing"
+)
+
+// returns the same key all the time
+func TestGlobalLimitKey(t *testing.T) {
+	limitkey := globalLimitKey{}
+
+	request := map[string]interface{}{}
+	key, err := limitkey.Key(request)
+	if err != nil || key != globalLimitKeyValue {
+		t.Errorf("Key %s did not match default global key", key)
+	}
+
+	request = map[string]interface{}{
+		"headers":   "boo",
+		"something": "does-not-matter",
+	}
+	key, err = limitkey.Key(request)
+	if err != nil || key != globalLimitKeyValue {
+		t.Errorf("Key %s did not match default global key", key)
+	}
+}


### PR DESCRIPTION
This added a LimitKey type called `global` that always returns a static `key` value. This would mean that used independently in a `limit` it would create a single bucket for all requests.

The *purpose* of doing this is to allow the use of sphinx to provide throughput request limiting for an application. E.g. an application only wants to handle a total of 200 requests a minute from all consumers irrespective of the user. A global limit can be used to enforce that overall limit. 

Since we use transactions for modifying redis keys, for managing limits this might add some latency on the total throughput of requests. Looking into redis documentation to see what the impact should be. We could also run benchmarks to evaluate.

I'm wondering if I should make this a warning in the logs or just in the documentation?

cc: @mtgao2 @kshen0 