### PR TITLE
decrease log rollup time frame

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+# v0.7.4 Decrease rollup window
+
 # v0.7.3: Add log rollups
 
 # v0.7.2: Update to use latest leakybucket

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -107,7 +107,7 @@ func (d *daemon) LoadConfig(newConfig config.Config) error {
 		return fmt.Errorf("unrecognized handler %s", d.proxy.Handler)
 	}
 
-	middleware.EnableRollups(context.Background(), logger.New("sphinx"), 20*time.Second)
+	middleware.EnableRollups(context.Background(), logger.New("sphinx"), 10*time.Second)
 	d.handler = middleware.New(handler, "sphinx", func(req *http.Request) map[string]interface{} {
 		return map[string]interface{}{
 			"guid": req.Header.Get("X-Request-Id"),

--- a/deb/sphinx/DEBIAN/control
+++ b/deb/sphinx/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: sphinx
-Version: 0.7.3
+Version: 0.7.4
 Section: base
 Priority: optional
 Architecture: amd64


### PR DESCRIPTION
We've been seeing memory issues after enabling rollups, decreasing the batch size may help?