### PR TITLE
Revert "decrease log rollup time frame" and make rollups smarter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,5 @@
+# v0.7.5 Revert rollup window change, and cut IDs out of rollups
+
 # v0.7.4 Decrease rollup window
 
 # v0.7.3: Add log rollups

--- a/deb/sphinx/DEBIAN/control
+++ b/deb/sphinx/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: sphinx
-Version: 0.7.4
+Version: 0.7.5
 Section: base
 Priority: optional
 Architecture: amd64


### PR DESCRIPTION
Reverts Clever/sphinx#88

Attempting to fix the high memory usage and container crashes in sphinx-api-clever we've been seeing since https://github.com/Clever/sphinx-api/pull/57
<img width="753" alt="Screen Shot 2021-02-12 at 11 58 36 AM" src="https://user-images.githubusercontent.com/50673502/107816466-aab4e280-6d29-11eb-9721-ac1a2866dd91.png">

https://production--haproxy-logs.int.clever.com/_plugin/kibana/app/kibana#/discover?_g=()&_a=(columns:!(method,op),index:'78e8dcb0-fff4-11e8-819f-3dbcf12e7319',interval:auto,query:(language:lucene,query:'container_app:sphinx-api-clever%20AND%20title:request-finished-rollup'),sort:!(!(timestamp,desc)))

- [x] pull into sphinx-api-clever and canary that (we don't really have a great way to see if this will help just using dev)