### PR TITLE
Use CI context for AWS auth

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,28 +1,34 @@
-version: 2
+version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.15
+    - image: circleci/golang:1.15
     environment:
       CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
       CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
     steps:
-      - run:
-          command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
-          name: Clone ci-scripts
-      - checkout
-      - restore_cache:
-          keys:
-          - go-mod-v1-{{ checksum "go.sum" }}
-      - setup_remote_docker
-      - run:
-          command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
-          name: Set up CircleCI artifacts directories
-      - run: make build
-      - run: make test
-      - run: $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
-      - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make VERSION && make deb && cp deb/sphinx.deb sphinx-amd64.deb && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN sphinx-amd64.deb; fi;
-      - save_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
-          paths:
-          - "/go/pkg/mod"
+    - run:
+        command: cd $HOME && git clone --depth 1 -v https://github.com/Clever/ci-scripts.git && cd ci-scripts && git show --oneline -s
+        name: Clone ci-scripts
+    - checkout
+    - restore_cache:
+        keys:
+        - go-mod-v1-{{ checksum "go.sum" }}
+    - setup_remote_docker
+    - run:
+        command: mkdir -p $CIRCLE_ARTIFACTS $CIRCLE_TEST_REPORTS
+        name: Set up CircleCI artifacts directories
+    - run: make build
+    - run: make test
+    - run: $HOME/ci-scripts/circleci/docker-publish $DOCKER_USER $DOCKER_PASS "$DOCKER_EMAIL" $DOCKER_ORG
+    - run: if [ "${CIRCLE_BRANCH}" == "master" ]; then make VERSION && make deb && cp deb/sphinx.deb sphinx-amd64.deb && $HOME/ci-scripts/circleci/github-release $GH_RELEASE_TOKEN sphinx-amd64.deb; fi;
+    - save_cache:
+        key: go-mod-v1-{{ checksum "go.sum" }}
+        paths:
+        - /go/pkg/mod
+workflows:
+  build_test_publish_deploy:
+    jobs:
+    - build:
+        context:
+        - aws-ecr-public


### PR DESCRIPTION
# Jira

[SECNG-1830](https://clever.atlassian.net/browse/SECNG-1830)

# Overview

This upgrades CircleCI config yamls to use 
`context: aws*` definitions.

There might be a whitespace that is created due to loading yaml into memory, processing, and writing back to file. 
You can use "Ignore white space in code review" toggle in Github PR view to simplify the code review: https://github.blog/2018-05-01-ignore-white-space-in-code-review/, which would add `?diff=unified&w=1` to the PR url.

# Testing
If the CI checks are green, it means it is working. PLEASE APPROVE AND MERGE THIS, if it is all good!

[SECNG-1830]: https://clever.atlassian.net/browse/SECNG-1830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ