### PR TITLE
SECNG-4492 | Install ca-certificates in base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:stable-slim
 
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates
+
 RUN mkdir -p /etc/sphinx
 
 COPY ./bin/sphinxd /usr/bin/sphinxd


### PR DESCRIPTION
## Clever Coding Standards Agreement

- [X] Author and Review Statement, "We agree this code adheres to our [Clever Global Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices?activeCard=a8a444f4-9149-4ec7-a0fd-8ba42519d93e) and other applicable [Coding Standards](https://app.getguru.com/folders/ibabX5oT/Engineering-Standards-Best-Practices)"

## JIRA
[SECNG-4492]

## Overview
-slim images do not have certificates [1]. Any outbound TLS connections will fail because of this. Not all features require this, but it's one of the main ones with some providers (DynamoDB).

It's not _necessary_ for the base image to do this. But it's convinient.

[1] https://github.com/debuerreotype/docker-debian-artifacts/issues/15

## Testing
(how did you test this)

## Rollout
(are there any special rollout considerations? specific steps? risks?)

## Rollback
(specific steps? risks?)

[SECNG-4492]: https://clever.atlassian.net/browse/SECNG-4492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ